### PR TITLE
feat: add catchProcessorException

### DIFF
--- a/packages/worker/src/interfaces.ts
+++ b/packages/worker/src/interfaces.ts
@@ -76,6 +76,25 @@ export type QueueWorkerExtraConfig = {
   ) => (QueueWorkerProcessorStatus | undefined | void) | Promise<QueueWorkerProcessorStatus | undefined | void>;
   // Run AFTER the message is processed
   postProcessor?: (name: string, ...args: Parameters<QueueWorkerProcessor>) => void | Promise<void>;
+
+  /**
+   * Exceptions thrown in the processor do not reach the top level and are not detected by the application. If you want to do something with processor exceptions, use this property.
+   * @example
+   * ```ts
+   * catchProcessorException: (error: Error) => {
+   *   captureException(error); // Sentry
+   * }
+   * ```
+   *
+   * @example
+   * ```ts
+   * catchProcessorException: async (error: Error) => {
+   *  // You can throw errors and let them reach the top level. Use an ExceptionFilter or similar to handle them appropriately.
+   *  throw error;
+   * }
+   * ```
+   */
+  catchProcessorException?: <T extends Error = Error>(error: T, raw: QueueWorkerRawMessage) => void | Promise<void>;
 };
 
 export interface QueueWorkerDecoratorArgs {

--- a/packages/worker/src/worker.service.ts
+++ b/packages/worker/src/worker.service.ts
@@ -120,6 +120,7 @@ export class QueueWorkerService {
         i = maxRetryAttempts;
       } catch (error: any) {
         this.logger.error(error.message);
+        await this.options.extraConfig?.catchProcessorException?.(error, raw);
       }
     }
   }


### PR DESCRIPTION
Exceptions thrown in the processor do not reach the top level and are not detected by the application. If you want to do something with processor exceptions, use this property.

```ts
catchProcessorException: (error: Error) => {
  captureException(error); // Sentry
}
```

```ts
catchProcessorException: (error: Error) => {
 // You can throw errors and let them reach the top level. Use an ExceptionFilter or similar to handle them appropriately.
 throw error;
}
```