### PR TITLE
feat: get workers/processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,36 @@ class Worker {
 }
 ```
 
+## Execute worker/processor manually
+
+You can execute worker/processor manually.
+
+```ts
+@Controller("/worker")
+class WorkerController {
+  constructor(private readonly service: QueueWorkerService) {}
+
+  @Post()
+  public async execute(@Body() body: QueueWorkerReceivedMessage): Promise<void> {
+    const workers = await this.service.getWorkers(body.message);
+
+    for (const worker of workers) {
+      const processors = worker.getProcessors();
+
+      for (const processor of processors) {
+        const result = await processor.execute();
+
+        if (result.success) {
+          console.log("Success");
+        } else {
+          console.log("Failed:" + result.error.message);
+        }
+      }
+    }
+  }
+}
+```
+
 ## Using Cloud Scheduler
 
 You can use Cloud Scheduler as trigger.
@@ -197,40 +227,4 @@ async function bootstrap(): Promise<void> {
 }
 
 bootstrap();
-```
-
-## Global Events
-
-This package is defined special event handlers.
-
-Note: `throwModuleError: true` is not working if you set global events.
-
-### UNHANDLED_QUEUE_WORKER
-
-You can listen to undefined worker name
-
-```typescript
-@QueueWorker(UNHANDLED_QUEUE_WORKER)
-class Worker {
-  @QueueWorkerProcess()
-  public async process(message: Message<any>, raw: QueueWorkerRawMessage): Promise<void> {
-    console.log("Message:", message);
-    console.log("Raw message:", raw);
-  }
-}
-```
-
-### ALL_QUEUE_WORKERS
-
-You can listen to all workers
-
-```typescript
-@QueueWorker(ALL_QUEUE_WORKERS)
-class Worker {
-  @QueueWorkerProcess()
-  public async process(message: Message<any>, raw: QueueWorkerRawMessage): Promise<void> {
-    console.log("Message:", message);
-    console.log("Raw message:", raw);
-  }
-}
 ```

--- a/packages/worker/src/constants.ts
+++ b/packages/worker/src/constants.ts
@@ -6,6 +6,3 @@ export const QUEUE_WORKER_PROCESS_DECORATOR = "QUEUE_WORKER_PROCESS_DECORATOR";
 export const ERROR_INVALID_MESSAGE_FORMAT = "Invalid message format.";
 export const ERROR_QUEUE_WORKER_NAME_NOT_FOUND = "QueueWorker name not found.";
 export const ERROR_WORKER_NOT_FOUND = (name: string): string => `QueueWorker '${name}' not found.`;
-
-export const UNHANDLED_QUEUE_WORKER_NAME = "__unhandled_queue_worker";
-export const ALL_WORKERS_QUEUE_WORKER_NAME = "__all_queue_workers";

--- a/packages/worker/src/explorer.service.spec.ts
+++ b/packages/worker/src/explorer.service.spec.ts
@@ -147,4 +147,77 @@ describe("QueueWorkerExplorerService", () => {
       },
     ]);
   });
+
+  it("priority", async () => {
+    @QueueWorker({ name: "TestWorker", priority: 1 })
+    class TestWorker {
+      @QueueWorkerProcess({ priority: 1 })
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      public async process1(): Promise<void> {}
+
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      @QueueWorkerProcess({ priority: 0 })
+      public async process2(): Promise<void> {}
+    }
+
+    @QueueWorker({ name: "TestWorker2", priority: 0 })
+    class TestWorker2 {
+      @QueueWorkerProcess({ priority: 0 })
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      public async process1(): Promise<void> {}
+
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      @QueueWorkerProcess({ priority: 1 })
+      public async process2(): Promise<void> {}
+    }
+
+    const app = await Test.createTestingModule({
+      imports: [QueueWorkerModule.register()],
+      providers: [TestWorker, TestWorker2],
+    }).compile();
+    const explorer = app.get<QueueWorkerExplorerService>(QueueWorkerExplorerService);
+    expect(explorer).toBeDefined();
+    expect(explorer.explore()).toEqual([
+      {
+        className: "TestWorker2",
+        instance: expect.any(TestWorker2),
+        name: "TestWorker2",
+        priority: 0,
+        processors: [
+          {
+            priority: 0,
+            processor: expect.any(Function),
+            processorName: "TestWorker2.process1",
+            workerName: "TestWorker2",
+          },
+          {
+            priority: 1,
+            processor: expect.any(Function),
+            processorName: "TestWorker2.process2",
+            workerName: "TestWorker2",
+          },
+        ],
+      },
+      {
+        className: "TestWorker",
+        instance: expect.any(TestWorker),
+        name: "TestWorker",
+        priority: 1,
+        processors: [
+          {
+            priority: 0,
+            processor: expect.any(Function),
+            processorName: "TestWorker.process2",
+            workerName: "TestWorker",
+          },
+          {
+            priority: 1,
+            processor: expect.any(Function),
+            processorName: "TestWorker.process1",
+            workerName: "TestWorker",
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/worker/src/explorer.service.ts
+++ b/packages/worker/src/explorer.service.ts
@@ -8,6 +8,7 @@ import {
   QueueWorkerProcessDecoratorArgs,
   QueueWorkerProcessorMetadata,
 } from "./interfaces";
+import { sortByPriority } from "./util";
 @Injectable()
 export class QueueWorkerExplorerService {
   constructor(
@@ -19,10 +20,10 @@ export class QueueWorkerExplorerService {
     const workers = this.getWorkers();
 
     for (const worker of workers) {
-      worker.processors = this.getQueueWorkerProcessors(worker);
+      worker.processors = sortByPriority(this.getQueueWorkerProcessors(worker));
     }
 
-    return workers;
+    return sortByPriority(workers);
   }
 
   private getWorkers(): QueueWorkerMetadata[] {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,13 +1,8 @@
-export {
-  ALL_WORKERS_QUEUE_WORKER_NAME as ALL_QUEUE_WORKERS,
-  UNHANDLED_QUEUE_WORKER_NAME as UNHANDLED_QUEUE_WORKER,
-} from "./constants";
 export { QueueWorker, QueueWorkerProcess } from "./decorators";
 export {
   QueueWorkerControllerInterface,
   QueueWorkerControllerMetadata,
   QueueWorkerDecodedMessage,
-  QueueWorkerExtraConfig,
   QueueWorkerModuleAsyncOptions,
   QueueWorkerModuleOptions,
   QueueWorkerModuleOptionsFactory,
@@ -17,11 +12,11 @@ export {
   QueueWorkerProcessResult,
   QueueWorkerProcessSuccessResult,
   QueueWorkerProcessor,
-  QueueWorkerProcessorStatus,
   QueueWorkerRawMessage,
   QueueWorkerReceivedMessage,
 } from "./interfaces";
 
 export { decodeMessage } from "./util";
+export { Processor, Worker } from "./worker";
 export { QueueWorkerModule } from "./worker.module";
 export { QueueWorkerService } from "./worker.service";

--- a/packages/worker/src/interfaces.ts
+++ b/packages/worker/src/interfaces.ts
@@ -26,14 +26,6 @@ export interface QueueWorkerModuleOptions extends ModuleOptions {
   maxRetryAttempts?: number;
 
   /**
-   * extra config
-   *
-   * @type {QueueWorkerExtraConfig}
-   * @memberof QueueWorkerModuleOptions
-   */
-  extraConfig?: QueueWorkerExtraConfig;
-
-  /**
    * Define a Route for the controller.
    * Default: POST /
    * If you provide your own Controller, set it to null.
@@ -52,11 +44,8 @@ export type QueueWorkerProcessor = <T>(message: T, raw: QueueWorkerRawMessage) =
 export interface QueueWorkerMetadata {
   className: string;
   instance: Injectable;
-
   processors: QueueWorkerProcessorMetadata[];
-
   name: QueueWorkerName;
-
   priority: number;
 }
 
@@ -65,21 +54,6 @@ export interface QueueWorkerProcessorMetadata extends QueueWorkerProcessDecorato
   processorName: string;
   processor: QueueWorkerProcessor;
 }
-
-export enum QueueWorkerProcessorStatus {
-  IN_PROGRESS = 0,
-  SKIP = 1,
-}
-
-export type QueueWorkerExtraConfig = {
-  // Run BEFORE the message is processed
-  preProcessor?: (
-    name: string,
-    ...args: Parameters<QueueWorkerProcessor>
-  ) => (QueueWorkerProcessorStatus | undefined | void) | Promise<QueueWorkerProcessorStatus | undefined | void>;
-  // Run AFTER the message is processed
-  postProcessor?: (name: string, ...args: Parameters<QueueWorkerProcessor>) => void | Promise<void>;
-};
 
 export interface QueueWorkerDecoratorArgs {
   names: QueueWorkerName[];
@@ -169,7 +143,7 @@ export interface QueueWorkerProcessOptions {
   enabled?: boolean;
 }
 
-type QueueWorkerProcessResultBase<T = any> = {
+export type QueueWorkerProcessResultBase<T = any> = {
   workerName: QueueWorkerName;
   processorName: string;
   data?: T;

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -1,6 +1,6 @@
 import { Message } from "@anchan828/nest-cloud-run-queue-common";
 import { BadRequestException } from "@nestjs/common";
-import { ERROR_INVALID_MESSAGE_FORMAT, ERROR_QUEUE_WORKER_NAME_NOT_FOUND } from "./constants";
+import { ERROR_INVALID_MESSAGE_FORMAT } from "./constants";
 import { QueueWorkerDecodedMessage, QueueWorkerRawMessage } from "./interfaces";
 
 const dateRegExp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
@@ -77,10 +77,6 @@ export function decodeMessage<T = any>(message: QueueWorkerRawMessage | Message)
   } else {
     // tasks / http
     data = message as Message<T>;
-  }
-
-  if (!data.name) {
-    throw new BadRequestException(ERROR_QUEUE_WORKER_NAME_NOT_FOUND);
   }
 
   return {

--- a/packages/worker/src/worker.controller.ts
+++ b/packages/worker/src/worker.controller.ts
@@ -19,7 +19,6 @@ export function getWorkerController(metadata?: QueueWorkerControllerMetadata): T
       @Body() body: QueueWorkerReceivedMessage,
       @Headers() headers: Record<string, string>,
     ): Promise<void> {
-      this.service.execute({});
       await this.service.execute({ ...body.message, headers });
     }
   }

--- a/packages/worker/src/worker.service.spec.ts
+++ b/packages/worker/src/worker.service.spec.ts
@@ -1,13 +1,7 @@
 import { Message } from "@anchan828/nest-cloud-run-queue-common";
 import { BadRequestException } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
-import {
-  ALL_WORKERS_QUEUE_WORKER_NAME,
-  ERROR_INVALID_MESSAGE_FORMAT,
-  ERROR_QUEUE_WORKER_NAME_NOT_FOUND,
-  ERROR_WORKER_NOT_FOUND,
-  UNHANDLED_QUEUE_WORKER_NAME,
-} from "./constants";
+import { ERROR_INVALID_MESSAGE_FORMAT, ERROR_QUEUE_WORKER_NAME_NOT_FOUND, ERROR_WORKER_NOT_FOUND } from "./constants";
 import { QueueWorkerExplorerService } from "./explorer.service";
 import {
   QueueWorkerMetadata,
@@ -46,31 +40,31 @@ describe("QueueWorkerService", () => {
     it("should throw error if data is not message object", async () => {
       await expect(
         service.execute({ data: toBase64("testtest"), messageId: "1" } as QueueWorkerRawMessage),
-      ).rejects.toThrowError(new BadRequestException(ERROR_INVALID_MESSAGE_FORMAT));
+      ).rejects.toThrow(new BadRequestException(ERROR_INVALID_MESSAGE_FORMAT));
     });
 
     it("should throw error if data invalid", async () => {
-      await expect(service.execute({ data: "invalid" } as QueueWorkerRawMessage)).rejects.toThrowError(
+      await expect(service.execute({ data: "invalid" } as QueueWorkerRawMessage)).rejects.toThrow(
         new BadRequestException(ERROR_QUEUE_WORKER_NAME_NOT_FOUND),
       );
     });
 
     it("should throw error if data is null", async () => {
-      await expect(service.execute({ data: null } as QueueWorkerRawMessage)).rejects.toThrowError(
+      await expect(service.execute({ data: null } as QueueWorkerRawMessage)).rejects.toThrow(
         new BadRequestException(ERROR_QUEUE_WORKER_NAME_NOT_FOUND),
       );
     });
 
     it("should throw error if message dosen't have name", async () => {
-      await expect(
-        service.execute({ data: toBase64({ data: "data" } as Message), messageId: "1" }),
-      ).rejects.toThrowError(new BadRequestException(ERROR_QUEUE_WORKER_NAME_NOT_FOUND));
+      await expect(service.execute({ data: toBase64({ data: "data" } as Message), messageId: "1" })).rejects.toThrow(
+        new BadRequestException(ERROR_QUEUE_WORKER_NAME_NOT_FOUND),
+      );
     });
 
     it("should throw error if worker not found", async () => {
-      await expect(
-        service.execute({ data: toBase64({ name: "name" } as Message), messageId: "1" }),
-      ).rejects.toThrowError(new BadRequestException(ERROR_WORKER_NOT_FOUND("name")));
+      await expect(service.execute({ data: toBase64({ name: "name" } as Message), messageId: "1" })).rejects.toThrow(
+        new BadRequestException(ERROR_WORKER_NOT_FOUND("name")),
+      );
     });
 
     it("should run processor if worker found (data is base64)", async () => {
@@ -139,25 +133,25 @@ describe("QueueWorkerService", () => {
 
   describe("tasks/http style", () => {
     it("should throw error if message is empty", async () => {
-      await expect(service.execute({} as QueueWorkerRawMessage)).rejects.toThrowError(
+      await expect(service.execute({} as QueueWorkerRawMessage)).rejects.toThrow(
         new BadRequestException(ERROR_QUEUE_WORKER_NAME_NOT_FOUND),
       );
     });
 
     it("should throw error if data is not message object", async () => {
-      await expect(service.execute({ test: "test" } as QueueWorkerRawMessage)).rejects.toThrowError(
+      await expect(service.execute({ test: "test" } as QueueWorkerRawMessage)).rejects.toThrow(
         ERROR_QUEUE_WORKER_NAME_NOT_FOUND,
       );
     });
 
     it("should throw error if message name is null", async () => {
-      await expect(service.execute({ name: null } as QueueWorkerRawMessage)).rejects.toThrowError(
+      await expect(service.execute({ name: null } as QueueWorkerRawMessage)).rejects.toThrow(
         new BadRequestException(ERROR_QUEUE_WORKER_NAME_NOT_FOUND),
       );
     });
 
     it("should throw error if worker not found", async () => {
-      await expect(service.execute({ name: "name" })).rejects.toThrowError(
+      await expect(service.execute({ name: "name" })).rejects.toThrow(
         new BadRequestException(ERROR_WORKER_NOT_FOUND("name")),
       );
     });
@@ -189,100 +183,6 @@ describe("QueueWorkerService", () => {
       ).resolves.toHaveLength(2);
       expect(processorMock).toHaveBeenCalledTimes(1);
     });
-  });
-
-  it("should run processor if ALL_WORKERS_QUEUE_WORKER_NAME worker found", async () => {
-    const processorMock = jest.fn().mockResolvedValueOnce("ok");
-    jest.spyOn(explorerService, "explore").mockReturnValueOnce([
-      {
-        className: "className",
-        name: ALL_WORKERS_QUEUE_WORKER_NAME,
-        priority: 0,
-        processors: [
-          { priority: 0, processor: processorMock, processorName: "processor", workerName: "worker" },
-        ] as QueueWorkerProcessorMetadata[],
-      },
-    ] as QueueWorkerMetadata[]);
-    const date = new Date();
-    const encodeData = toBase64({ data: { date, prop: 1 }, name: "name" });
-
-    await expect(service.execute({ attributes: { attr: 2 }, data: encodeData, messageId: "1" })).resolves.toEqual([]);
-    expect(processorMock).toHaveBeenCalledWith(
-      { data: { date, prop: 1 }, name: "name" },
-      { attributes: { attr: 2 }, data: encodeData, messageId: "1" },
-    );
-  });
-
-  it("should run processor if UNHANDLED_QUEUE_WORKER_NAME worker found", async () => {
-    const processorMock = jest.fn().mockResolvedValueOnce("ok");
-    jest.spyOn(explorerService, "explore").mockReturnValueOnce([
-      {
-        name: UNHANDLED_QUEUE_WORKER_NAME,
-        priority: 0,
-        processors: [
-          { priority: 0, processor: processorMock, processorName: "processor", workerName: "worker" },
-        ] as QueueWorkerProcessorMetadata[],
-      },
-    ] as QueueWorkerMetadata[]);
-    await expect(
-      service.execute({
-        attributes: { attr: 2 },
-        data: toBase64({ data: { date: new Date(), prop: 1 }, name: "name" }),
-        messageId: "1",
-      }),
-    ).resolves.toEqual([]);
-    expect(processorMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("priority", async () => {
-    const processorMock = jest.fn();
-    jest.spyOn(explorerService, "explore").mockReturnValueOnce([
-      {
-        name: "name",
-        priority: 2,
-        processors: [
-          { priority: 2, processor: () => processorMock(5), processorName: "processor", workerName: "worker" },
-          { priority: 1, processor: () => processorMock(4), processorName: "processor", workerName: "worker" },
-          { priority: 3, processor: () => processorMock(6), processorName: "processor", workerName: "worker" },
-        ] as QueueWorkerProcessorMetadata[],
-      },
-      {
-        name: "name",
-        priority: 1,
-        processors: [
-          { priority: 2, processor: () => processorMock(2), processorName: "processor", workerName: "worker" },
-          { priority: 1, processor: () => processorMock(1), processorName: "processor", workerName: "worker" },
-          { priority: 3, processor: () => processorMock(3), processorName: "processor", workerName: "worker" },
-        ] as QueueWorkerProcessorMetadata[],
-      },
-      {
-        name: ALL_WORKERS_QUEUE_WORKER_NAME,
-        priority: 1,
-        processors: [
-          { priority: 2, processor: () => processorMock(8), processorName: "processor", workerName: "worker" },
-          { priority: 1, processor: () => processorMock(7), processorName: "processor", workerName: "worker" },
-          { priority: 3, processor: () => processorMock(9), processorName: "processor", workerName: "worker" },
-        ] as QueueWorkerProcessorMetadata[],
-      },
-    ] as QueueWorkerMetadata[]);
-
-    await expect(
-      service.execute({
-        attributes: { attr: 2 },
-        data: toBase64({ data: { date: new Date(), prop: 1 }, name: "name" }),
-        messageId: "1",
-      }),
-    ).resolves.toHaveLength(6);
-    expect(processorMock).toHaveBeenCalledTimes(9);
-    expect(processorMock).toHaveBeenNthCalledWith(1, 1);
-    expect(processorMock).toHaveBeenNthCalledWith(2, 2);
-    expect(processorMock).toHaveBeenNthCalledWith(3, 3);
-    expect(processorMock).toHaveBeenNthCalledWith(4, 4);
-    expect(processorMock).toHaveBeenNthCalledWith(5, 5);
-    expect(processorMock).toHaveBeenNthCalledWith(6, 6);
-    expect(processorMock).toHaveBeenNthCalledWith(7, 7);
-    expect(processorMock).toHaveBeenNthCalledWith(8, 8);
-    expect(processorMock).toHaveBeenNthCalledWith(9, 9);
   });
 
   it("maxRetryAttempts", async () => {
@@ -342,5 +242,52 @@ describe("QueueWorkerService", () => {
       }),
     ).resolves.toHaveLength(1);
     expect(processorMock).toHaveBeenCalledWith({ prop: 1 }, { data: { prop: 1 }, name: "name" });
+  });
+
+  describe("getWorkers", () => {
+    it("should get empty array (invalid message)", async () => {
+      expect(service.getWorkers({})).toEqual([]);
+    });
+
+    it("should get workers", async () => {
+      const processorMock = jest.fn().mockReturnThis();
+
+      jest.spyOn(explorerService, "explore").mockReturnValueOnce([
+        {
+          name: "name",
+          priority: 0,
+          processors: [
+            {
+              priority: 0,
+              processor: processorMock,
+              processorName: "processor",
+              workerName: "name",
+            } as QueueWorkerProcessorMetadata,
+          ],
+        },
+      ] as QueueWorkerMetadata[]);
+
+      expect(service.getWorkers({ data: { prop: 1 }, name: "name" })).toEqual([
+        {
+          message: {
+            data: { data: { prop: 1 }, name: "name" },
+            raw: { data: { prop: 1 }, name: "name" },
+          },
+          metadata: {
+            name: "name",
+            priority: 0,
+            processors: [
+              {
+                priority: 0,
+                processor: processorMock,
+                processorName: "processor",
+                workerName: "name",
+              },
+            ],
+          },
+          options: { throwModuleError: true },
+        },
+      ]);
+    });
   });
 });

--- a/packages/worker/src/worker.service.ts
+++ b/packages/worker/src/worker.service.ts
@@ -1,23 +1,17 @@
-import { BadRequestException, Inject, Injectable, Logger } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable } from "@nestjs/common";
 
 import { Message } from "@anchan828/nest-cloud-run-queue-common";
-import {
-  ALL_WORKERS_QUEUE_WORKER_NAME,
-  ERROR_WORKER_NOT_FOUND,
-  QUEUE_WORKER_MODULE_OPTIONS,
-  UNHANDLED_QUEUE_WORKER_NAME,
-} from "./constants";
+import { ERROR_QUEUE_WORKER_NAME_NOT_FOUND, ERROR_WORKER_NOT_FOUND, QUEUE_WORKER_MODULE_OPTIONS } from "./constants";
 import { QueueWorkerExplorerService } from "./explorer.service";
 import {
   QueueWorkerDecodedMessage,
   QueueWorkerMetadata,
   QueueWorkerModuleOptions,
-  QueueWorkerProcessorMetadata,
-  QueueWorkerProcessorStatus,
   QueueWorkerProcessResult,
   QueueWorkerRawMessage,
 } from "./interfaces";
-import { decodeMessage, sortByPriority } from "./util";
+import { decodeMessage } from "./util";
+import { Worker } from "./worker";
 
 @Injectable()
 export class QueueWorkerService {
@@ -30,122 +24,59 @@ export class QueueWorkerService {
     return this.#_allWorkers;
   }
 
-  get #spetialWorkers(): QueueWorkerMetadata[] {
-    return (this.#_allWorkers || []).filter((worker) =>
-      [ALL_WORKERS_QUEUE_WORKER_NAME, UNHANDLED_QUEUE_WORKER_NAME].includes(worker.name),
-    );
-  }
-
   constructor(
     @Inject(QUEUE_WORKER_MODULE_OPTIONS)
     private readonly options: QueueWorkerModuleOptions,
-    private readonly logger: Logger,
     private readonly explorerService: QueueWorkerExplorerService,
   ) {}
 
-  public async execute<T = any>(meessage: Message<T>): Promise<QueueWorkerProcessResult<T>[]>;
-
-  public async execute<T = any>(meessage: QueueWorkerDecodedMessage<T>): Promise<QueueWorkerProcessResult<T>[]>;
-
-  public async execute<T = any>(meessage: QueueWorkerRawMessage<T>): Promise<QueueWorkerProcessResult<T>[]>;
-
+  /**
+   * Execute all workers that match the worker name. If you want to execute a each worker, use `getWorkers` method.
+   */
   public async execute<T = any>(
     meessage: QueueWorkerRawMessage<T> | QueueWorkerDecodedMessage<T> | Message<T>,
   ): Promise<QueueWorkerProcessResult<T>[]> {
-    return await this.runWorkers(this.isDecodedMessage(meessage) ? meessage : decodeMessage(meessage));
-  }
+    const decodedMessage = this.isDecodedMessage(meessage) ? meessage : decodeMessage(meessage);
 
-  /**
-   * @deprecated Use `decodeMessage` function instead.
-   */
-  public decodeMessage<T = any>(message: QueueWorkerRawMessage | Message): QueueWorkerDecodedMessage<T> {
-    return decodeMessage(message);
-  }
+    if (this.options.throwModuleError && !decodedMessage.data.name) {
+      throw new BadRequestException(ERROR_QUEUE_WORKER_NAME_NOT_FOUND);
+    }
 
-  private async runWorkers<T = any>(
-    decodedMessage: QueueWorkerDecodedMessage<T>,
-  ): Promise<QueueWorkerProcessResult<T>[]> {
-    const maxRetryAttempts = this.options.maxRetryAttempts ?? 1;
-    const workers: QueueWorkerMetadata[] = [];
+    const workers = await this.getWorkers(decodedMessage);
 
-    workers.push(...this.#allWorkers.filter((worker) => decodedMessage.data.name === worker.name));
-
-    if (this.options?.throwModuleError && workers.length === 0 && this.#spetialWorkers.length === 0) {
+    if (this.options.throwModuleError && workers.length === 0) {
       throw new BadRequestException(ERROR_WORKER_NOT_FOUND(decodedMessage.data.name));
     }
 
-    const processors = sortByPriority(workers)
-      .map((w) => sortByPriority(w.processors))
-      .flat();
+    const results: QueueWorkerProcessResult<T>[] = [];
 
-    const spetialProcessors = sortByPriority(this.#spetialWorkers)
-      .map((w) => sortByPriority(w.processors))
-      .flat();
-    const QueueWorkerProcessResults: QueueWorkerProcessResult<T>[] = [];
-    const processorStatus = await this.options.extraConfig?.preProcessor?.(
-      decodedMessage.data.name,
-      decodedMessage.data.data,
-      decodedMessage.raw,
-    );
-
-    if (processorStatus !== QueueWorkerProcessorStatus.SKIP) {
-      for (const processor of processors) {
-        QueueWorkerProcessResults.push(
-          await this.executeProcessor(processor, maxRetryAttempts, decodedMessage.data.data, decodedMessage.raw),
-        );
-      }
-
-      for (const processor of spetialProcessors) {
-        await this.executeProcessor(processor, maxRetryAttempts, decodedMessage.data, decodedMessage.raw);
-      }
+    for (const worker of workers) {
+      results.push(...(await worker.execute()));
     }
 
-    await this.options.extraConfig?.postProcessor?.(
-      decodedMessage.data.name,
-      decodedMessage.data.data,
-      decodedMessage.raw,
-    );
+    return results;
+  }
 
-    return QueueWorkerProcessResults;
+  /**
+   * Get all workers that match the worker name. Use this method to execute manually when you want to execute only on specific conditions using metadata such as class name or processor name.
+   * If you want to execute all workers simply, use `execute` method.
+   */
+  public getWorkers<T = any>(
+    meessage: QueueWorkerRawMessage<T> | QueueWorkerDecodedMessage<T> | Message<T>,
+  ): Worker<T>[] {
+    const decodedMessage = this.isDecodedMessage(meessage) ? meessage : decodeMessage(meessage);
+    if (!decodedMessage.data.name) {
+      return [];
+    }
+
+    return this.#allWorkers
+      .filter((worker) => decodedMessage.data.name === worker.name)
+      .map((metadata) => new Worker(decodedMessage, metadata, this.options));
   }
 
   private isDecodedMessage<T = any>(
     message: QueueWorkerRawMessage<T> | QueueWorkerDecodedMessage<T> | Message<T>,
   ): message is QueueWorkerDecodedMessage<T> {
     return "raw" in message;
-  }
-
-  private async executeProcessor<T = any>(
-    processorMetadata: QueueWorkerProcessorMetadata,
-    maxRetryAttempts: number,
-    data: T | undefined,
-    raw: QueueWorkerRawMessage,
-  ): Promise<QueueWorkerProcessResult<T>> {
-    for (let i = 0; i < maxRetryAttempts; i++) {
-      try {
-        await processorMetadata.processor(data, raw);
-        i = maxRetryAttempts;
-      } catch (error: any) {
-        this.logger.error(error.message);
-        if (maxRetryAttempts === i + 1) {
-          return {
-            data,
-            error,
-            processorName: processorMetadata.processorName,
-            raw,
-            success: false,
-            workerName: processorMetadata.workerName,
-          };
-        }
-      }
-    }
-
-    return {
-      data,
-      processorName: processorMetadata.processorName,
-      raw,
-      success: true,
-      workerName: processorMetadata.workerName,
-    };
   }
 }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1,0 +1,100 @@
+import {
+  QueueWorkerDecodedMessage,
+  QueueWorkerMetadata,
+  QueueWorkerModuleOptions,
+  QueueWorkerProcessorMetadata,
+  QueueWorkerProcessResult,
+  QueueWorkerProcessResultBase,
+} from "./interfaces";
+
+export class Worker<T> {
+  get name(): string {
+    return this.metadata.name;
+  }
+
+  get priority(): number {
+    return this.metadata.priority;
+  }
+
+  get className(): string {
+    return this.metadata.className;
+  }
+
+  constructor(
+    private readonly message: QueueWorkerDecodedMessage<T>,
+    private readonly metadata: QueueWorkerMetadata,
+    private readonly options: QueueWorkerModuleOptions,
+  ) {}
+
+  /**
+   * Execute all processors in the worker. If you want to execute a each processor, use `getProcessors` method.
+   */
+  public async execute(): Promise<QueueWorkerProcessResult[]> {
+    const results: QueueWorkerProcessResult[] = [];
+    const processors = this.getProcessors();
+    for (const processor of processors) {
+      results.push(await processor.execute());
+    }
+    return results;
+  }
+
+  /**
+   * Get all processors in the worker. Use this method to execute manually when you want to execute only on specific conditions using metadata such as class name or processor name.
+   */
+  public getProcessors(): Processor<T>[] {
+    return this.metadata.processors.map((processor) => new Processor(this.message, processor, this.options));
+  }
+}
+
+export class Processor<T> {
+  get name(): string {
+    return this.metadata.processorName;
+  }
+
+  get priority(): number {
+    return this.metadata.priority;
+  }
+
+  get workerName(): string {
+    return this.metadata.workerName;
+  }
+
+  constructor(
+    private readonly message: QueueWorkerDecodedMessage<T>,
+    private readonly metadata: QueueWorkerProcessorMetadata,
+    private readonly options: QueueWorkerModuleOptions,
+  ) {}
+
+  /**
+   * Execute the processor.
+   */
+  public async execute(): Promise<QueueWorkerProcessResult<T>> {
+    const maxRetryAttempts = this.options.maxRetryAttempts ?? 1;
+
+    const resultBase: QueueWorkerProcessResultBase<T> = {
+      data: this.message.data.data,
+      processorName: this.metadata.processorName,
+      raw: this.message.raw,
+      workerName: this.metadata.workerName,
+    };
+
+    for (let i = 0; i < maxRetryAttempts; i++) {
+      try {
+        await this.metadata.processor(this.message.data.data, this.message.raw);
+        i = maxRetryAttempts;
+      } catch (error: any) {
+        if (maxRetryAttempts === i + 1) {
+          return {
+            error,
+            success: false,
+            ...resultBase,
+          };
+        }
+      }
+    }
+    return {
+      success: true,
+      ...resultBase,
+    };
+  }
+}


### PR DESCRIPTION
## Execute worker/processor manually

You can execute worker/processor manually.

```ts
@Controller("/worker")
class WorkerController {
  constructor(private readonly service: QueueWorkerService) {}

  @Post()
  public async execute(@Body() body: QueueWorkerReceivedMessage): Promise<void> {
    const workers = await this.service.getWorkers(body.message);

    for (const worker of workers) {
      const processors = worker.getProcessors();

      for (const processor of processors) {
        const result = await processor.execute();

        if (result.success) {
          console.log("Success");
        } else {
          console.log("Failed:" + result.error.message);
        }
      }
    }
  }
}
```

## Breaking changes
* Remove `Global Events`: Removed `__unhandled_queue_worker` and `__all_queue_workers`
* Remove config.extraConfig: Removed `preProcessor` and `postProcessor`
