### PR TITLE
feat: support deduplication

### DIFF
--- a/packages/tasks-publisher/src/interfaces.ts
+++ b/packages/tasks-publisher/src/interfaces.ts
@@ -20,6 +20,6 @@ export type TasksPublisherModuleOptionsFactory = ModuleOptionsFactory<TasksPubli
 
 export type PublishConfig = Omit<google.cloud.tasks.v2.ITask, "name">;
 
-export type PublishOptions = { queue?: string } & PublishConfig;
+export type PublishOptions = { queue?: string, deduplicationId?: string, } & PublishConfig;
 
 export type PublishData<T> = Message<T>;

--- a/packages/tasks-publisher/src/publish.service.ts
+++ b/packages/tasks-publisher/src/publish.service.ts
@@ -16,9 +16,12 @@ export class TasksPublisherService {
       ? await this.options.extraConfig?.prePublish(message)
       : message;
 
+    const queue = options?.queue || this.options.queue;
+
     const [task] = await this.client.createTask({
-      parent: options?.queue || this.options.queue,
+      parent: queue,
       task: {
+        name: options?.deduplicationId ? `${queue}/${options.deduplicationId}` : undefined,
         ...this.options.publishConfig,
         ...options,
         httpRequest: {

--- a/packages/tasks-publisher/src/publish.service.ts
+++ b/packages/tasks-publisher/src/publish.service.ts
@@ -21,7 +21,7 @@ export class TasksPublisherService {
     const [task] = await this.client.createTask({
       parent: queue,
       task: {
-        name: options?.deduplicationId ? `${queue}/${options.deduplicationId}` : undefined,
+        name: options?.deduplicationId ? `${queue}/tasks/${options.deduplicationId}` : undefined,
         ...this.options.publishConfig,
         ...options,
         httpRequest: {


### PR DESCRIPTION
Hello

and thanks for the great module!

I just added a small feature to support deduplication within cloud-tasks.
So cloud-tasks deduplicatates tasks automaticly by it's name. 
See docs here: https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks/create#body.request_body.FIELDS.task

thanks, jochen